### PR TITLE
Fix issues with line endings on Windows

### DIFF
--- a/src/gen-harfbuzzcc.py
+++ b/src/gen-harfbuzzcc.py
@@ -12,7 +12,7 @@ CURRENT_SOURCE_DIR = sys.argv[2]
 sources = sys.argv[3:]
 
 with open (OUTPUT, "wb") as f:
-	f.write ("".join ('#include "{}"\n'.format (os.path.basename (x)) for x in sources if x.endswith (".cc")).encode ())
+	f.write ("".join ('#include "{}"{}'.format (os.path.basename (x), os.linesep) for x in sources if x.endswith (".cc")).encode ())
 
 # copy it also to src/
 shutil.copyfile (OUTPUT, os.path.join (CURRENT_SOURCE_DIR, os.path.basename (OUTPUT)))

--- a/src/gen-hb-version.py
+++ b/src/gen-hb-version.py
@@ -23,7 +23,7 @@ try:
 except IOError:
 	pass
 
-with open (INPUT, "r", encoding='utf-8') as template:
+with open (INPUT, "r", encoding='utf-8', newline='') as template:
 	with open (OUTPUT, "wb") as output:
 		output.write (template.read ()
 			.replace ("@HB_VERSION_MAJOR@", major)


### PR DESCRIPTION
gen-harfbuzzcc and gen-hb-version scripts convert CRLF on Windows to LF - causing issues to our versioning logic. This should prevent modification of line endings